### PR TITLE
Prevent mutation of the original style

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,12 +11,20 @@ var regExp = /&/gi
 module.exports = function (rule) {
     var stylesheet = rule.stylesheet
     var style = rule.style
+    var nextStyle = {}
 
     for (var prop in style) {
+        if (!style.hasOwnProperty(prop)) continue
+        
         if (prop[0] == '&') {
             var selector = prop.replace(regExp, rule.selector)
             rule.addChild(selector, style[prop], {named: false})
-            delete style[prop]
+        }
+        
+        else {
+            nextStyle[prop] = style[prop]
         }
     }
+    
+    rule.style = nextStyle
 }


### PR DESCRIPTION
An example use case is when rendering server side, the first time after a server restart, a `:focus` selector will be rendered correctly. But the second time the pseudo selector will be missing from the original style object and the rule child won't be added.

The `hasOwnProperty` is not related, but I didn't want to make another pull request.